### PR TITLE
Issue #19: Resources in routes must be singular

### DIFF
--- a/src/Type/OpenApi.php
+++ b/src/Type/OpenApi.php
@@ -153,13 +153,13 @@ COMM;
 
         if ($apiGetCollectionHandler->exists()) {
             $class
-                ->useClass($apiDeleteResourceHandler->getComponent()->getFqcn())
+                ->useClass($apiGetCollectionHandler->getComponent()->getFqcn())
                 ->useClass($collection->getFqcn());
 
             // phpcs:disable Generic.Files.LineLength.TooLong
             $comments[] = <<<COMM
 /**
- * @see {$apiDeleteResourceHandler->getComponent()->getClassName()}::handle()
+ * @see {$apiGetCollectionHandler->getComponent()->getClassName()}::handle()
  */
 #[OA\Get(
     path: '/{$entity->toKebabCase()}',

--- a/src/Type/RoutesDelegator.php
+++ b/src/Type/RoutesDelegator.php
@@ -140,10 +140,10 @@ COMM)
             $invoke->appendBody(
                 sprintf(
                     '->get(\'/%s\', %s, \'%s::list-%s\')',
-                    Component::pluralize($entity->toKebabCase()),
+                    $entity->toKebabCase(),
                     $apiGetCollectionHandler->getComponent()->getClassString(),
                     $entity->toKebabCase(),
-                    Component::pluralize($entity->toKebabCase()),
+                    $entity->toKebabCase(),
                 ),
                 12
             );

--- a/test/Type/OpenApiTest.php
+++ b/test/Type/OpenApiTest.php
@@ -155,6 +155,7 @@ namespace Api\ModuleName;
 use Api\ModuleName\Collection\ModuleNameCollection;
 use Api\ModuleName\Entity\ModuleName;
 use Api\ModuleName\Handler\ModuleName\DeleteModuleNameResourceHandler;
+use Api\ModuleName\Handler\ModuleName\GetModuleNameCollectionHandler;
 use Api\ModuleName\Handler\ModuleName\GetModuleNameResourceHandler;
 use Api\ModuleName\Handler\ModuleName\PatchModuleNameResourceHandler;
 use Api\ModuleName\Handler\ModuleName\PostModuleNameResourceHandler;
@@ -225,7 +226,7 @@ use OpenApi\Attributes as OA;
 )]
 
 /**
- * @see DeleteModuleNameResourceHandler::handle()
+ * @see GetModuleNameCollectionHandler::handle()
  */
 #[OA\Get(
     path: '/module-name',

--- a/test/Type/RoutesDelegatorTest.php
+++ b/test/Type/RoutesDelegatorTest.php
@@ -224,7 +224,7 @@ class RoutesDelegator
         \$routeCollector
             ->delete('/book-store/' . \$uuid, DeleteBookStoreResourceHandler::class, 'book-store::delete-book-store')
             ->get('/book-store/' . \$uuid, GetBookStoreResourceHandler::class, 'book-store::view-book-store')
-            ->get('/book-stores', GetBookStoreCollectionHandler::class, 'book-store::list-book-stores')
+            ->get('/book-store', GetBookStoreCollectionHandler::class, 'book-store::list-book-store')
             ->patch('/book-store/' . \$uuid, PatchBookStoreResourceHandler::class, 'book-store::update-book-store')
             ->post('/book-store', PostBookStoreResourceHandler::class, 'book-store::create-book-store')
             ->put('/book-store/' . \$uuid, PutBookStoreResourceHandler::class, 'book-store::replace-book-store');


### PR DESCRIPTION
Also, fixed a file reference bug in `src/Type/OpenApi.php` where I pointed the `GET collection` action to the `DeleteResourceHandler` instead of the `GetCollectionHandler`.